### PR TITLE
use gpt-4o-mini, fixed manual request checks

### DIFF
--- a/APIKey.py
+++ b/APIKey.py
@@ -13,10 +13,12 @@ class APIKey:
             self.default_org = ""
             self.organizations = []
             self.rpm = 0
+            self.tpm = 0
             self.tier = ""
             self.has_special_models = False
             self.real_32k = False
             self.the_one = False
+
 
         elif provider == Provider.ANTHROPIC:
             self.pozzed = False


### PR DESCRIPTION
In this commit, I've changed the checker to use gpt-4o-mini, as it is better and more future-proof to use than gpt-3.5-turbo and gpt-4.
gpt-3.5-turbo and gpt-4 are models that are going to get deprecated later (maybe later this year).

I've also fixed check_manual_increase returning RPM increased via request for Free and Tier 1 keys.
This was incorrect, as for free and tier 1 keys it returns RPD, not RPM.