### PR TITLE
Added gpt-image-1 + verified orgs  check

### DIFF
--- a/APIKey.py
+++ b/APIKey.py
@@ -18,6 +18,7 @@ class APIKey:
             self.the_one = False
             self.extra_models = False
             self.extra_model_list = set()
+            self.has_verified_org = False
 
         elif provider == Provider.ANTHROPIC:
             self.pozzed = False

--- a/OpenAI.py
+++ b/OpenAI.py
@@ -267,7 +267,7 @@ def pretty_print_oai_keys(keys, cloned_keys):
             org_count += 1
         if key.tier == 'Tier5':
             t5_count += 1
-        if key.has_verified_org:
+        if key.has_verified_org and key.has_quota and key.rpm > 0:
             verified_org_keys.append(key)
             verified_orgs_count += 1
         if key.has_quota:
@@ -338,7 +338,7 @@ def pretty_print_oai_keys(keys, cloned_keys):
     
     # Add section for verified organizations
     if verified_org_keys:
-        print(f'\n--- Verified Organizations ({verified_orgs_count} keys with access to gpt-image-1 model) ---')
+        print(f'\n--- Verified Organizations ({verified_orgs_count} keys with access to gpt-image-1 model and quota) ---')
         for key in verified_org_keys:
             print(f"{key.api_key}"
                   + (f" | default org - {key.default_org}" if key.default_org else "")


### PR DESCRIPTION
Openai has added a new "option" to verify your organization to gain some perks, until today it was just access to o3 streaming and reasoning summaries via their responses api, but with the new gpt-image-1 api release they made that inclusive to verified orgs (outside of some special cases).
Makes it a perfect way to check for verified orgs.